### PR TITLE
feat: add in-app language selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ clicking it opens the full panel — Session, History, Hardware, and Settings.
     *   A **JARVIS-style arc-reactor HUD** with rotating tick rings and a glowing core that pulses with charging power.
     *   At-a-glance power, battery health, and temperature, plus quick toggles (widget, reset, animations, notifications).
 *   **🌍 Localization:**
-    *   Full English, Turkish, and Simplified Chinese (简体中文) UI, automatically following the macOS system language.
+    *   Full English, Turkish, and Simplified Chinese (简体中文) UI. Follow the macOS system language or choose a language in MacWake Settings; restart to apply the change. The WidgetKit extension continues to use its own system-provided language environment.
 *   **📊 Detailed Session Tracking (Current Session):** 
     *   Tracks screen-on time and sleep duration.
     *   Seamless data integrity with restart/shutdown detection.

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -68,3 +68,14 @@
 "Limit %d%%" = "Limit %d%%";
 "INTENT_LIMIT_SET_FMT" = "Charge limit set to %d%%.";
 "INTENT_STATUS_FMT" = "Battery %1$d%%, %2$@, health %3$d%%, temperature %4$.1f°C.";
+
+/* App language selector */
+"Language" = "Language";
+"Follow System" = "Follow System";
+"Restart MacWake to apply language changes" = "Restart MacWake to apply language changes";
+"MacWake needs to restart before the selected language appears." = "MacWake needs to restart before the selected language appears.";
+"Later" = "Later";
+"Restart Now" = "Restart Now";
+"MacWake couldn't restart" = "MacWake couldn't restart";
+"Quit and reopen MacWake to apply the language change." = "Quit and reopen MacWake to apply the language change.";
+"OK" = "OK";

--- a/Resources/tr.lproj/Localizable.strings
+++ b/Resources/tr.lproj/Localizable.strings
@@ -359,3 +359,14 @@
 "DYNAMIC_ISLAND_HELP" = "Şarj durumu, uyarılar ve hızlı kontroller içeren çentik tarzı bir katman gösterir.";
 "HAPTICS_HELP" = "Dynamic Island açılıp kapandığında hafif bir trackpad tıklaması hissettirir.";
 "MENUBAR_POWER_HELP" = "Şarj olurken watt değerini, pil ile çalışırken ekranda geçirilen süreyi gösterir.";
+
+/* App language selector */
+"Language" = "Dil";
+"Follow System" = "Sistem Dilini Kullan";
+"Restart MacWake to apply language changes" = "Dil değişikliklerini uygulamak için MacWake'i yeniden başlat";
+"MacWake needs to restart before the selected language appears." = "Seçilen dilin görünmesi için MacWake'in yeniden başlatılması gerekiyor.";
+"Later" = "Daha Sonra";
+"Restart Now" = "Şimdi Yeniden Başlat";
+"MacWake couldn't restart" = "MacWake yeniden başlatılamadı";
+"Quit and reopen MacWake to apply the language change." = "Dil değişikliğini uygulamak için MacWake'ten çıkıp yeniden açın.";
+"OK" = "Tamam";

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -369,3 +369,14 @@
 "DYNAMIC_ISLAND_HELP" = "显示刘海样式浮层，其中包含充电状态、提醒和快捷控制。";
 "HAPTICS_HELP" = "Dynamic Island 打开或关闭时，通过触控板提供轻微的点按反馈。";
 "MENUBAR_POWER_HELP" = "接通电源时显示充电功率，使用电池时显示亮屏时间。";
+
+/* App language selector */
+"Language" = "语言";
+"Follow System" = "跟随系统";
+"Restart MacWake to apply language changes" = "重启 MacWake 以应用语言更改";
+"MacWake needs to restart before the selected language appears." = "所选语言将在 MacWake 重启后显示。";
+"Later" = "稍后";
+"Restart Now" = "立即重启";
+"MacWake couldn't restart" = "无法重启 MacWake";
+"Quit and reopen MacWake to apply the language change." = "请退出并重新打开 MacWake 以应用语言更改。";
+"OK" = "确定";

--- a/Sources/AppLanguagePreference.swift
+++ b/Sources/AppLanguagePreference.swift
@@ -1,0 +1,98 @@
+import AppKit
+import Foundation
+
+struct AppLanguage: Identifiable, Hashable {
+    let id: String
+    let displayName: String
+}
+
+enum AppLanguagePreference {
+    private static let appleLanguagesKey = "AppleLanguages"
+
+    static let supportedLanguages: [AppLanguage] = Array(Set(Bundle.main.localizations))
+        .filter { $0 != "Base" }
+        .sorted()
+        .map { identifier in
+            let locale = Locale(identifier: identifier)
+            return AppLanguage(
+                id: identifier,
+                displayName: locale.localizedString(forIdentifier: identifier) ?? identifier
+            )
+        }
+
+    static var selectedLanguageIdentifier: String? {
+        guard
+            let bundleIdentifier = Bundle.main.bundleIdentifier,
+            let appDomain = UserDefaults.standard.persistentDomain(forName: bundleIdentifier),
+            let storedIdentifier = (appDomain[appleLanguagesKey] as? [String])?.first
+        else {
+            return nil
+        }
+
+        let supported = supportedLanguages
+        let normalizedStored = storedIdentifier.replacingOccurrences(of: "_", with: "-").lowercased()
+        if let exact = supported.first(where: { $0.id.lowercased() == normalizedStored }) {
+            return exact.id
+        }
+
+        if let regionalMatch = supported.first(where: {
+            let candidate = $0.id.lowercased()
+            return normalizedStored.hasPrefix(candidate + "-") || candidate.hasPrefix(normalizedStored + "-")
+        }) {
+            return regionalMatch.id
+        }
+
+        let storedLanguageCode = Locale(identifier: storedIdentifier).language.languageCode?.identifier
+        let languageMatches = supported.filter {
+            Locale(identifier: $0.id).language.languageCode?.identifier == storedLanguageCode
+        }
+        return languageMatches.count == 1 ? languageMatches[0].id : nil
+    }
+
+    static func select(_ identifier: String?) {
+        if let identifier {
+            UserDefaults.standard.set([identifier], forKey: appleLanguagesKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: appleLanguagesKey)
+        }
+        // The next process reads this during Bundle initialization, so flush before a
+        // possible immediate restart instead of relying on the normal deferred write.
+        UserDefaults.standard.synchronize()
+    }
+
+    /// Starts a short-lived helper that waits for this process to finish before asking
+    /// Launch Services to reopen the same bundle. Waiting avoids racing the single-instance
+    /// guard in MacWakeApp.init().
+    @MainActor
+    static func restart() -> Bool {
+        let helper = Process()
+        helper.executableURL = URL(fileURLWithPath: "/bin/sh")
+        helper.arguments = [
+            "-c",
+            """
+            pid="$1"
+            bundle="$2"
+            attempts=0
+            while kill -0 "$pid" 2>/dev/null; do
+                attempts=$((attempts + 1))
+                [ "$attempts" -ge 100 ] && exit 1
+                sleep 0.1
+            done
+            exec /usr/bin/open "$bundle"
+            """,
+            "macwake-relaunch",
+            String(ProcessInfo.processInfo.processIdentifier),
+            Bundle.main.bundleURL.path
+        ]
+
+        do {
+            try helper.run()
+        } catch {
+            print("Failed to schedule MacWake restart: \(error)")
+            return false
+        }
+
+        NSApplication.shared.terminate(nil)
+        return true
+    }
+}

--- a/Sources/MacWakeMenuView.swift
+++ b/Sources/MacWakeMenuView.swift
@@ -20,6 +20,9 @@ struct MacWakeMenuView: View {
     @State private var isCLIInstalled = CLIInstaller.isInstalled
     #endif
     @State private var processSortMode: Int = 0 // 0 = CPU, 1 = RAM
+    @State private var selectedAppLanguage = AppLanguagePreference.selectedLanguageIdentifier
+    @State private var showLanguageRestartAlert = false
+    @State private var showLanguageRestartError = false
     private let timer = Timer.publish(every: 1.0, on: .main, in: .common).autoconnect()
     @State private var timerActive = true
     @State private var secondsTick = 0
@@ -177,6 +180,21 @@ struct MacWakeMenuView: View {
                 processMonitor.refresh()
             }
             #endif
+        }
+        .alert("Restart MacWake to apply language changes", isPresented: $showLanguageRestartAlert) {
+            Button("Later", role: .cancel) {}
+            Button("Restart Now") {
+                if !AppLanguagePreference.restart() {
+                    DispatchQueue.main.async { showLanguageRestartError = true }
+                }
+            }
+        } message: {
+            Text("MacWake needs to restart before the selected language appears.")
+        }
+        .alert("MacWake couldn't restart", isPresented: $showLanguageRestartError) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Quit and reopen MacWake to apply the language change.")
         }
     }
 
@@ -401,12 +419,44 @@ struct MacWakeMenuView: View {
                 set: { v in isLaunchAtLoginEnabled = v; LaunchAgentManager.setEnabled(v) })
     }
 
+    private var appLanguageBinding: Binding<String?> {
+        Binding(
+            get: { selectedAppLanguage },
+            set: { identifier in
+                guard identifier != selectedAppLanguage else { return }
+                selectedAppLanguage = identifier
+                AppLanguagePreference.select(identifier)
+                showLanguageRestartAlert = true
+            }
+        )
+    }
+
+    private var languageRow: some View {
+        HStack(spacing: 11) {
+            iconTile("globe", .cyan)
+            Text("Language").font(.subheadline)
+            Spacer()
+            Picker("", selection: appLanguageBinding) {
+                Text("Follow System").tag(nil as String?)
+                ForEach(AppLanguagePreference.supportedLanguages) { language in
+                    Text(language.displayName).tag(Optional(language.id))
+                }
+            }
+            .pickerStyle(.menu)
+            .labelsHidden()
+            .controlSize(.small)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
+    }
+
     private var settingsTabContent: some View {
         VStack(spacing: 10) {
             notificationPermissionRow
             
             sectionLabel("General")
             settingsCard {
+                languageRow
+                rowDivider()
                 toggleRow("rectangle.on.rectangle", .blue, "Show Desktop Widget", $tracker.showWidget, help: "WIDGET_HELP")
                 if tracker.showWidget {
                     rowDivider()

--- a/build.sh
+++ b/build.sh
@@ -51,12 +51,6 @@ cat <<EOF > "${CONTENTS_DIR}/Info.plist"
     <string>Wake</string>
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
-    <key>CFBundleLocalizations</key>
-    <array>
-        <string>en</string>
-        <string>tr</string>
-        <string>zh-Hans</string>
-    </array>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>


### PR DESCRIPTION
## Summary

- add an in-app language selector to the General settings card with Follow System, English, Türkçe, and 简体中文
- discover supported languages from the app bundle so future localizations do not require core selector changes
- persist the per-app language through the app's `AppleLanguages` domain and offer an immediate restart action
- wait for the existing process to exit before reopening MacWake, preserving the single-instance guard
- localize the new settings and restart UI in English, Turkish, and Simplified Chinese
- let copied `.lproj` resources declare bundle localizations instead of maintaining a hard-coded localization list
- document that the WidgetKit extension continues to use its own system-provided language environment

## Test plan

- [x] `plutil -lint` for all three `Localizable.strings` files
- [x] `bash -n build.sh`
- [x] `git diff --check`
- [x] native Release build
- [x] swiftbuild Release build
- [x] App Store Release build with `-DAPPSTORE`
- [x] verified English, Turkish, and Simplified Chinese bundle localization resolution
- [x] verified Follow System removes the app-specific override while ignoring merged global language defaults
- [x] verified Restart Now changes the process ID and keeps exactly one MacWake instance
- [x] verified menu, Settings, notification, onboarding, App Intent, and Widget strings in all three current languages

## Notes

- Language changes intentionally take effect after restarting MacWake; this avoids a broad live-localization refactor.
- The WidgetKit extension remains an independent bundle and follows its own system-provided language environment.
- The full packaging script completed compilation, resource copying, App Intents metadata generation, and shortcut validation. Formal Developer ID signing could not run on the test machine because the maintainer's signing identity is not installed.
